### PR TITLE
Open files in unit tests even if they're already in use

### DIFF
--- a/RocketLeagueReplayParser/Replay.cs
+++ b/RocketLeagueReplayParser/Replay.cs
@@ -11,7 +11,7 @@ namespace RocketLeagueReplayParser
     {
         public static Replay Deserialize(string filePath)
         {
-            using(var fs = new FileStream(filePath, FileMode.Open))
+            using(var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             using(var br = new BinaryReader(fs))
             {
                 return Deserialize(br);


### PR DESCRIPTION
Tests were failing to complete because files were "in use". This allows the tests to read from the file even if it is already open in another program.